### PR TITLE
Analyze code for syntax error

### DIFF
--- a/tiktok-song-extractor.html
+++ b/tiktok-song-extractor.html
@@ -495,14 +495,14 @@
         function copyBookmarklet() {
             const bookmarklet = `javascript:(function(){
                 var script = document.createElement('script');
-                script.src = 'data:text/javascript;base64,' + btoa(\`
-                    ${extractSongs.toString()}
-                    ${extractSongData.toString()}
-                    ${displayResults.toString()}
-                    ${copyAllSongs.toString()}
-                    ${getProfileName.toString()}
+                script.src = 'data:text/javascript;base64,' + btoa('
+                    ' + ${extractSongs.toString()} + '
+                    ' + ${extractSongData.toString()} + '
+                    ' + ${displayResults.toString()} + '
+                    ' + ${copyAllSongs.toString()} + '
+                    ' + ${getProfileName.toString()} + '
                     extractSongs();
-                \`);
+                ');
                 document.head.appendChild(script);
             })();`;
             


### PR DESCRIPTION
Fix `SyntaxError: Unexpected token '<'` in `copyBookmarklet` by replacing an invalid nested template literal with string concatenation.

---
<a href="https://cursor.com/background-agent?bcId=bc-7080be4d-b59e-420a-984a-ee870efefcc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7080be4d-b59e-420a-984a-ee870efefcc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

